### PR TITLE
Update dragover function to check if user is dragging a file.

### DIFF
--- a/src/jquery.ezdz.js
+++ b/src/jquery.ezdz.js
@@ -78,11 +78,13 @@
             // Build the container
             $container = $('<div class="' + settings.classes.main + '" />')
 
-            .on('dragover.ezdz', function() {
-                $(this).addClass(settings.classes.enter);
-
-                if ($.isFunction(settings.enter)) {
-                     settings.enter.apply(this);
+            .on('dragover.ezdz', function(e) {
+                var dt = e.originalEvent.dataTransfer;
+                if (dt.types && (dt.types.indexOf ? dt.types.indexOf('Files') != -1 : dt.types.contains('Files'))) {
+                    $(this).addClass(settings.classes.enter);
+                    if ($.isFunction(settings.enter)) {
+                        settings.enter.apply(this);
+                    }
                 }
             })
 


### PR DESCRIPTION
Using a sorting plugin, I've noticed that when I dragged one ezdz on top of another, the enter class was being added. 

This change will verify if the object that the user is dragging is a file and not an element.

Based on this answer: https://stackoverflow.com/a/8494918/4802649